### PR TITLE
refactor: extract logic from playgroundApp into managers

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -20,7 +20,7 @@ const buildOptions = {
   legalComments: "none",
   bundle: true,
   target: "es2022",
-  entryPoints: ["src/main.ts", "src/preview.ts", "src/compilation-worker.ts"],
+  entryPoints: ["src/main.tsx", "src/preview.ts", "src/compilation-worker.ts"],
   entryNames: "[name]",
   loader: {
     ".json": "json",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,0 @@
-import "./helpers/reset.css";
-import "./main.css";
-import { PlaygroundApp } from "./playground-app";
-
-const app = new PlaygroundApp();
-await app.loadSavedProjects();
-app.showUI(document.getElementById("root")!);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,30 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { PlaygroundApp } from "./playground-app";
+import { Editor } from "./components/editor";
+import "./helpers/reset.css";
+import "./main.css";
+
+const root = createRoot(document.getElementById("root")!);
+
+const app = new PlaygroundApp(() => {
+  const project = app.projects.getActiveProject();
+  root.render(
+    <StrictMode>
+      <Editor
+        openFiles={project?.openFiles ?? []}
+        selectedFileIdx={project?.selectedFileIdx ?? -1}
+        fileTreeItems={project?.fileTreeItems ?? []}
+        savedProjectNames={app.savedProjectNames}
+        onTabClick={app.selectOpenedFile}
+        onTabClose={app.closeOpenFile}
+        onOpenLocal={app.openLocalProject}
+        onFileTreeItemClick={app.onFileTreeItemClick}
+        onOpenSaved={app.openSavedProject}
+        onClearSaved={app.removeSavedProject}
+      />
+    </StrictMode>,
+  );
+});
+
+await app.loadSavedProjects();

--- a/src/playground-app.tsx
+++ b/src/playground-app.tsx
@@ -1,189 +1,74 @@
 import { extname } from "@file-services/path";
 import { del, get, update } from "idb-keyval";
-import React from "react";
-import { createRoot, type Root } from "react-dom/client";
-import { type Compilation, type LibraryVersions } from "./compilation-worker";
 import { Editor } from "./components/editor";
-import type { IndentedList } from "./components/indented-list";
-import {
-  compilationBundleName,
-  compilationWorkerName,
-  defaultLibVersions,
-  ignoredFileTreeDirectories,
-  openProjectsIDBKey,
-} from "./constants";
-import { generateIndentedFsItems } from "./fs/async-fs-operations";
+import { openProjectsIDBKey } from "./constants";
 import { createBrowserFileSystem, type BrowserFileSystem } from "./fs/browser-file-system";
 import { imageMimeTypes } from "./helpers/dom";
-import { clamp, collectIntoArray, ignoreRejections } from "./helpers/javascript";
-import type { Preview } from "./preview";
-import { createRPCIframe, type RPCIframe } from "./rpc/rpc-iframe";
-import { createRPCWorker, type RPCWorker } from "./rpc/rpc-worker";
-import { getCoduxConfig } from "./helpers/codux";
+import { ignoreRejections } from "./helpers/javascript";
+import { ProjectsManager } from "./projects-manager";
 
 export class PlaygroundApp {
-  private fs: BrowserFileSystem | undefined;
-
-  private appRoot: Root | undefined;
-  private openDirectories = new Set<string>();
+  projects = new ProjectsManager();
+  savedProjectNames?: readonly string[] | undefined;
   private savedDirectoryHandles?: Record<string, FileSystemDirectoryHandle> | undefined;
-  private compilation?: RPCWorker<Compilation> | undefined;
-  private previews = new Map<string, RPCIframe<Preview>>();
-
-  // passed to UI
-  private openFiles: readonly Editor.OpenFile[] = [];
-  private selectedFileIdx = -1;
-  private fileTreeItems: readonly IndentedList.Item[] | undefined;
-  private savedProjectNames?: readonly string[] | undefined;
-
-  public showUI(container: HTMLElement) {
-    this.appRoot = createRoot(container);
-    this.renderApp();
-  }
-
-  public async loadSavedProjects() {
-    const savedDirectoryHandles = await get<Record<string, FileSystemDirectoryHandle>>(openProjectsIDBKey);
-    this.savedDirectoryHandles = savedDirectoryHandles;
-    this.savedProjectNames = savedDirectoryHandles && Object.keys(savedDirectoryHandles);
-  }
-
-  private renderApp() {
-    this.appRoot?.render(
-      <React.StrictMode>
-        <Editor
-          openFiles={this.openFiles}
-          selectedFileIdx={this.selectedFileIdx}
-          fileTreeItems={this.fileTreeItems}
-          savedProjectNames={this.savedProjectNames}
-          onTabClick={this.onTabClick}
-          onOpenLocal={this.onOpenLocal}
-          onFileTreeItemClick={this.onFileTreeItemClick}
-          onOpenSaved={this.onOpenSaved}
-          onClearSaved={this.onClearSaved}
-          onTabClose={this.onTabClose}
-          onPreviewLoad={this.registerPreview}
-          onPreviewClose={this.closePreview}
-        />
-      </React.StrictMode>,
-    );
-  }
-
-  private registerPreview = async (filePath: string, iframe: HTMLIFrameElement) => {
-    const previewRPC = createRPCIframe<Preview>(iframe);
-    const existingRPC = this.previews.get(filePath);
-    if (existingRPC) {
-      existingRPC.close();
-    }
-    this.previews.set(filePath, previewRPC);
-
-    const coduxCodux = await getCoduxConfig(this.fs!, "/");
-    const boardGlobalSetupPath = coduxCodux?.boardGlobalSetup
-      ? await this.compilation?.api.resolveSpecifier(this.fs!.root, "/", coduxCodux.boardGlobalSetup)
-      : undefined;
-
-    const entryModules = boardGlobalSetupPath ? [boardGlobalSetupPath, filePath] : filePath;
-    const moduleGraph = await this.compilation?.api.calculateModuleGraph(this.fs!.root, entryModules);
-    if (moduleGraph && this.previews.get(filePath) === previewRPC) {
-      await previewRPC.api.evaluateAndRender(
-        moduleGraph,
-        filePath,
-        boardGlobalSetupPath ? boardGlobalSetupPath : undefined,
-      );
-    }
-  };
-
-  private closePreview = (filePath: string) => {
-    const previewRPC = this.previews.get(filePath);
-    if (previewRPC) {
-      previewRPC.close();
-      this.previews.delete(filePath);
-    }
-  };
-
-  private onFileTreeItemClick = async (itemId: string, itemType: string, altKey: boolean) => {
-    if (itemType === "directory") {
-      if (this.openDirectories.has(itemId)) {
-        this.openDirectories.delete(itemId);
-      } else {
-        this.openDirectories.add(itemId);
-      }
-      await this.calculateFileTreeItems();
-    } else if (itemType === "file") {
-      const itemIdx = this.openFiles.findIndex(({ filePath }) => itemId === filePath);
-      if (itemIdx !== -1) {
-        this.selectedFileIdx = itemIdx;
-      } else if (this.fs && (await this.fs.fileExists(itemId))) {
-        const fileExtension = extname(itemId);
-        const imageMimeType = imageMimeTypes.get(fileExtension);
-        const openFile: Editor.OpenFile = imageMimeType
-          ? {
-              type: "image-viewer",
-              filePath: itemId,
-              imageUrl: URL.createObjectURL(new Blob([await this.fs.readFile(itemId)], { type: imageMimeType })),
-            }
-          : altKey
-          ? { type: "preview", filePath: itemId }
-          : {
-              type: "code-editor",
-              filePath: itemId,
-              fileContents: await this.fs.readTextFile(itemId),
-            };
-        this.openFiles = [...this.openFiles, openFile];
-        this.selectedFileIdx = this.openFiles.length - 1;
-      }
-    }
-    this.renderApp();
-  };
-
-  private onTabClick = (tabId: string) => {
-    this.selectedFileIdx = this.openFiles.findIndex(({ filePath }) => tabId === filePath);
-    this.renderApp();
-  };
-
-  private closeFile = (openFile: Editor.OpenFile) => {
-    if (openFile.type === "image-viewer") {
-      URL.revokeObjectURL(openFile.imageUrl);
-    }
-  };
-
-  private onTabClose = (tabId: string) => {
-    const { openFiles } = this;
-    const targetFileIdx = openFiles.findIndex(({ filePath }) => tabId === filePath);
-    if (targetFileIdx === -1) {
+  constructor(private changeSignal: () => void) {}
+  onFileTreeItemClick = async (filePath: string, itemType: string, altKey: boolean) => {
+    const project = this.projects.getActiveProject();
+    if (!project) {
       return;
     }
-    this.closeFile(openFiles[targetFileIdx]!);
-    this.openFiles = [...openFiles.slice(0, targetFileIdx), ...openFiles.slice(targetFileIdx + 1)];
-    if (targetFileIdx === this.selectedFileIdx) {
-      this.selectedFileIdx = this.openFiles.length ? clamp(targetFileIdx, 0, this.openFiles.length - 1) : -1;
-    } else if (this.selectedFileIdx > targetFileIdx) {
-      this.selectedFileIdx--;
+    const { id, fs, openDirectories, openFiles } = project;
+    if (itemType === "directory") {
+      if (openDirectories.has(filePath)) {
+        openDirectories.delete(filePath);
+      } else {
+        openDirectories.add(filePath);
+      }
+      await this.projects.updateFileTreeItems(id);
+    } else if (itemType === "file") {
+      const itemIdx = openFiles.findIndex(({ filePath: match }) => filePath === match);
+      if (itemIdx !== -1) {
+        this.projects.updateSelectedFileIdx(id, itemIdx);
+      } else if (await fs.fileExists(filePath)) {
+        const openFile = await this.getOpenFileType(filePath, fs, altKey);
+        this.projects.openFile(id, openFile);
+      }
     }
-    this.renderApp();
+    this.changeSignal?.();
   };
 
-  private async setRootDirectoryHandle(directoryHandle: FileSystemDirectoryHandle) {
-    for (const openFile of this.openFiles) {
-      this.closeFile(openFile);
+  selectOpenedFile = (filePath: string) => {
+    const project = this.projects.getActiveProject();
+    if (!project) {
+      return;
     }
-    this.openFiles = [];
-    this.openDirectories.clear();
-    this.fs = createBrowserFileSystem(directoryHandle);
-    await this.calculateFileTreeItems();
-    this.renderApp();
-    await this.initializeProject(this.fs);
-  }
+    project.selectedFileIdx = project.openFiles.findIndex(({ filePath: match }) => match === filePath);
+    this.changeSignal?.();
+  };
 
-  private onOpenLocal = async () => {
+  closeOpenFile = (tabId: string) => {
+    const project = this.projects.getActiveProject();
+    if (!project) {
+      return;
+    }
+    const file = this.projects.closeFile(project.id, tabId);
+    if (file) {
+      this.closeFileCleanup(file);
+    }
+    this.changeSignal?.();
+  };
+
+  openLocalProject = async () => {
     const directoryHandle = await ignoreRejections(window.showDirectoryPicker());
     if (directoryHandle) {
       await this.saveProject(directoryHandle);
       await this.loadSavedProjects();
-      await this.setRootDirectoryHandle(directoryHandle);
+      await this.projects.openProject(directoryHandle.name, createBrowserFileSystem(directoryHandle));
+      this.changeSignal?.();
     }
   };
 
-  private onOpenSaved = async (projectName: string) => {
+  openSavedProject = async (projectName: string) => {
     const savedDirectoryHandle = this.savedDirectoryHandles?.[projectName];
     if (!savedDirectoryHandle) {
       return;
@@ -191,8 +76,22 @@ export class PlaygroundApp {
     if (!(await this.handleHasPermission(savedDirectoryHandle))) {
       return;
     }
-    await this.setRootDirectoryHandle(savedDirectoryHandle);
+    await this.projects.openProject(savedDirectoryHandle.name, createBrowserFileSystem(savedDirectoryHandle));
+    this.changeSignal?.();
   };
+
+  removeSavedProject = async () => {
+    await del(openProjectsIDBKey);
+    await this.loadSavedProjects();
+    this.changeSignal?.();
+  };
+
+  async loadSavedProjects() {
+    const savedDirectoryHandles = await get<Record<string, FileSystemDirectoryHandle>>(openProjectsIDBKey);
+    this.savedDirectoryHandles = savedDirectoryHandles;
+    this.savedProjectNames = savedDirectoryHandles && Object.keys(savedDirectoryHandles);
+    this.changeSignal?.();
+  }
 
   private async saveProject(directoryHandle: FileSystemDirectoryHandle) {
     await update<Record<string, FileSystemDirectoryHandle>>(openProjectsIDBKey, (savedProjects = {}) => {
@@ -208,53 +107,30 @@ export class PlaygroundApp {
     return (await fileSystemHandle.requestPermission()) === "granted";
   }
 
-  private onClearSaved = async () => {
-    await del(openProjectsIDBKey);
-    await this.loadSavedProjects();
-    this.renderApp();
-  };
+  // TODO: move to preview management
+  private async getOpenFileType(itemId: string, fs: BrowserFileSystem, showAsPreview: boolean) {
+    const fileExtension = extname(itemId);
+    const imageMimeType = imageMimeTypes.get(fileExtension);
+    const openFile: Editor.OpenFile = imageMimeType
+      ? {
+          type: "image-viewer",
+          filePath: itemId,
+          imageUrl: URL.createObjectURL(new Blob([await fs.readFile(itemId)], { type: imageMimeType })),
+        }
+      : showAsPreview
+      ? { type: "preview", filePath: itemId }
+      : {
+          type: "code-editor",
+          filePath: itemId,
+          fileContents: await fs.readTextFile(itemId),
+        };
 
-  private async calculateFileTreeItems() {
-    this.fileTreeItems = this.fs
-      ? await collectIntoArray(
-          generateIndentedFsItems(await this.fs.openDirectory("/"), this.openDirectories, ignoredFileTreeDirectories),
-        )
-      : undefined;
+    return openFile;
   }
 
-  private async initializeProject(fs: BrowserFileSystem) {
-    this.compilation?.close();
-    const compilationWorkerURL = new URL(compilationBundleName, import.meta.url);
-    const compilationWorker = createRPCWorker<Compilation>(compilationWorkerURL, {
-      name: compilationWorkerName,
-      type: "module",
-    });
-    this.compilation = compilationWorker;
-
-    const rootPackageLockPath = "/package-lock.json";
-    const libVersions = (await fs.fileExists(rootPackageLockPath))
-      ? this.getLibVersions((await fs.readJSONFile(rootPackageLockPath)) as PackageLock)
-      : defaultLibVersions;
-    await compilationWorker.api.initialize(libVersions);
-    // const contents = await compilationWorker.api.compile("/a.ts", `export const a = 123;\nthrow new Error('wow');`);
-    // console.log(contents);
-    // (0, eval)(`(function (exports){${contents}\n})({})`);
-  }
-
-  private getLibVersions({ packages = {} }: PackageLock): LibraryVersions {
-    const typescriptVersion = packages[packagePath("typescript")]?.version ?? defaultLibVersions.typescript;
-    const sassVersion = packages[packagePath("sass")]?.version ?? defaultLibVersions.sass;
-    const immutableVersion =
-      packages[packagePath(`sass/${packagePath("immutable")}`)]?.version ??
-      packages[packagePath("immutable")]?.version ??
-      defaultLibVersions.immutable;
-
-    return { typescript: typescriptVersion, sass: sassVersion, immutable: immutableVersion };
+  private closeFileCleanup(openFile: Editor.OpenFile) {
+    if (openFile.type === "image-viewer") {
+      URL.revokeObjectURL(openFile.imageUrl);
+    }
   }
 }
-
-interface PackageLock {
-  packages?: Record<string, { version?: string }>;
-}
-
-const packagePath = <T extends string>(packageName: T) => `node_modules/${packageName}` as const;

--- a/src/preview-manager.tsx
+++ b/src/preview-manager.tsx
@@ -1,0 +1,50 @@
+import { type Compilation } from "./compilation-worker";
+import { type BrowserFileSystem } from "./fs/browser-file-system";
+import type { Preview } from "./preview";
+import { createRPCIframe, type RPCIframe } from "./rpc/rpc-iframe";
+import { type RPCWorker } from "./rpc/rpc-worker";
+import { getCoduxConfig } from "./helpers/codux";
+
+export class PreviewManager {
+  constructor(
+    private fs: BrowserFileSystem,
+    private compilation: RPCWorker<Compilation>,
+    private previews = new Map<string, RPCIframe<Preview>>()
+  ) { }
+  registerPreview = async (filePath: string, iframe: HTMLIFrameElement) => {
+    const previewRPC = createRPCIframe<Preview>(iframe);
+    const existingRPC = this.previews.get(filePath);
+    if (existingRPC) {
+      existingRPC.close();
+    }
+    this.previews.set(filePath, previewRPC);
+
+    const coduxCodux = await getCoduxConfig(this.fs, "/");
+    const boardGlobalSetupPath = coduxCodux?.boardGlobalSetup
+      ? await this.compilation?.api.resolveSpecifier(this.fs.root, "/", coduxCodux.boardGlobalSetup)
+      : undefined;
+
+    const entryModules = boardGlobalSetupPath ? [boardGlobalSetupPath, filePath] : filePath;
+    const moduleGraph = await this.compilation?.api.calculateModuleGraph(this.fs.root, entryModules);
+    if (moduleGraph && this.previews.get(filePath) === previewRPC) {
+      await previewRPC.api.evaluateAndRender(
+        moduleGraph,
+        filePath,
+        boardGlobalSetupPath ? boardGlobalSetupPath : undefined
+      );
+    }
+  };
+  closePreview = (filePath: string) => {
+    const previewRPC = this.previews.get(filePath);
+    if (previewRPC) {
+      previewRPC.close();
+      this.previews.delete(filePath);
+    }
+  };
+  closeAll() {
+    for (const previewRPC of this.previews.values()) {
+      previewRPC.close();
+    }
+    this.previews.clear();
+  }
+}

--- a/src/projects-manager.tsx
+++ b/src/projects-manager.tsx
@@ -1,0 +1,150 @@
+import { type Compilation, type LibraryVersions } from "./compilation-worker";
+import { Editor } from "./components/editor";
+import type { IndentedList } from "./components/indented-list";
+import {
+  compilationBundleName,
+  compilationWorkerName,
+  defaultLibVersions,
+  ignoredFileTreeDirectories,
+} from "./constants";
+import { generateIndentedFsItems } from "./fs/async-fs-operations";
+import type { BrowserFileSystem } from "./fs/browser-file-system";
+import { clamp, collectIntoArray } from "./helpers/javascript";
+import { createRPCWorker, type RPCWorker } from "./rpc/rpc-worker";
+import { PreviewManager } from "./preview-manager";
+
+export interface ProjectHost {
+  id: string;
+  fs: BrowserFileSystem;
+  compilation: RPCWorker<Compilation>;
+  previews: PreviewManager;
+  openDirectories: Set<string>;
+  fileTreeItems: readonly IndentedList.Item[] | undefined;
+  openFiles: readonly Editor.OpenFile[];
+  selectedFileIdx: number;
+}
+
+export class ProjectsManager {
+  private activeProjects = new Map<string, ProjectHost>();
+  private lastOpenedProject?: string;
+  getActiveProject() {
+    if (!this.lastOpenedProject) {
+      return;
+    }
+    return this.getProject(this.lastOpenedProject);
+  }
+  getProject(id: string): ProjectHost {
+    const projectHost = this.activeProjects.get(id);
+    if (!projectHost) {
+      throw new Error(`Project ${id} not found`);
+    }
+    return projectHost;
+  }
+  async openProject(id: string, fs: BrowserFileSystem) {
+    if (this.activeProjects.has(id)) {
+      return this.getProject(id);
+    }
+    // TODO: we are closing all until we handle multiple open projects in gui
+    this.closeAllProjects();
+    const projectHost = await this.createProjectHost(id, fs);
+    this.lastOpenedProject = id;
+    this.activeProjects.set(id, projectHost);
+    return projectHost;
+  }
+  closeProject(id: string) {
+    const projectServices = this.activeProjects.get(id);
+    if (projectServices) {
+      projectServices.compilation.close();
+      projectServices.previews.closeAll();
+      this.activeProjects.delete(id);
+    }
+  }
+  closeAllProjects() {
+    for (const project of this.activeProjects.values()) {
+      this.closeProject(project.id);
+    }
+    this.activeProjects.clear();
+  }
+
+  openFile(id: string, openFile: Editor.OpenFile) {
+    const projectHost = this.getProject(id);
+    projectHost.selectedFileIdx = projectHost.openFiles.length;
+    projectHost.openFiles = [...projectHost.openFiles, openFile];
+  }
+  closeFile(id: string, filePathToClose: string) {
+    const project = this.getProject(id);
+    const { openFiles, selectedFileIdx } = project;
+    const targetFileIdx = openFiles.findIndex(({ filePath }) => filePathToClose === filePath);
+    if (targetFileIdx === -1) {
+      return;
+    }
+    const openFile = openFiles[targetFileIdx]!;
+
+    // this.closeFile(openFiles[targetFileIdx]!);
+    project.openFiles = [...openFiles.slice(0, targetFileIdx), ...openFiles.slice(targetFileIdx + 1)];
+    if (targetFileIdx === selectedFileIdx) {
+      project.selectedFileIdx = openFiles.length ? clamp(targetFileIdx, 0, openFiles.length - 1) : -1;
+    } else if (project.selectedFileIdx > targetFileIdx) {
+      project.selectedFileIdx--;
+    }
+    return openFile;
+  }
+  updateSelectedFileIdx(id: string, selectedFileIdx: number) {
+    const projectHost = this.getProject(id);
+    projectHost.selectedFileIdx = selectedFileIdx;
+  }
+  async updateFileTreeItems(id: string) {
+    const projectHost = this.getProject(id);
+    projectHost.fileTreeItems = await this.calculateFileTreeItems(projectHost.fs, projectHost.openDirectories);
+  }
+  private async createProjectHost(id: string, fs: BrowserFileSystem): Promise<ProjectHost> {
+    const compilation = await this.createCompilation(fs);
+    const previews = new PreviewManager(fs, compilation);
+    const openDirectories = new Set<string>();
+    const fileTreeItems = await this.calculateFileTreeItems(fs, openDirectories);
+    return {
+      id,
+      fs,
+      compilation,
+      previews,
+      fileTreeItems,
+      openDirectories,
+      openFiles: [],
+      selectedFileIdx: -1,
+    };
+  }
+  private async createCompilation(fs: BrowserFileSystem) {
+    const compilationWorkerURL = new URL(compilationBundleName, import.meta.url);
+    const compilationWorker = createRPCWorker<Compilation>(compilationWorkerURL, {
+      name: compilationWorkerName,
+      type: "module",
+    });
+    const rootPackageLockPath = "/package-lock.json";
+    const libVersions = (await fs.fileExists(rootPackageLockPath))
+      ? this.getLibVersions((await fs.readJSONFile(rootPackageLockPath)) as PackageLock)
+      : defaultLibVersions;
+    await compilationWorker.api.initialize(libVersions);
+    return compilationWorker;
+  }
+  private getLibVersions({ packages = {} }: PackageLock): LibraryVersions {
+    const typescriptVersion = packages[packagePath("typescript")]?.version ?? defaultLibVersions.typescript;
+    const sassVersion = packages[packagePath("sass")]?.version ?? defaultLibVersions.sass;
+    const immutableVersion =
+      packages[packagePath(`sass/${packagePath("immutable")}`)]?.version ??
+      packages[packagePath("immutable")]?.version ??
+      defaultLibVersions.immutable;
+
+    return { typescript: typescriptVersion, sass: sassVersion, immutable: immutableVersion };
+  }
+  private async calculateFileTreeItems(fs: BrowserFileSystem, openDirectories: Set<string>) {
+    return await collectIntoArray(
+      generateIndentedFsItems(await fs.openDirectory("/"), openDirectories, ignoredFileTreeDirectories),
+    );
+  }
+}
+
+interface PackageLock {
+  packages?: Record<string, { version?: string }>;
+}
+
+const packagePath = <T extends string>(packageName: T) => `node_modules/${packageName}` as const;


### PR DESCRIPTION
This PR separates the logic of project management into it's own class. that class does not depend on any `FileSystemHandle` it gets the `fs` for the project in the open project stage. this also means that the compilation service can be opened per project and we can possibly open more then one project at the same time.

I also moved all GUI related things to the `main.tsx` since the app can be potentially run standalone.

There are few more things to finish after this:
1. move `openFile` types to preview manager
2. get rid of `getActiveProject` in favor of GUI to handle multiple open projects.
3. there will be a small degradation of open project time since we are now waiting for the services before rendering, 
4. `ProjectHost` can be a class and it will save few functions on the manager and cleanup the code even more. 