### PR TITLE
perf: implement compile and handle caches

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,8 @@ import { version as tsVersion } from "typescript/package.json";
 import { version as immutableVersion } from "immutable/package.json";
 import type { LibraryVersions } from "./compilation-worker";
 
+export const playgroundDbName = "core3-playground";
+export const compilationCacheStoreName = "compilation-cache";
 export const openProjectsIDBKey = "playground-projects";
 export const compilationWorkerName = "Compilation";
 export const compilationBundleName = "compilation-worker.js";


### PR DESCRIPTION
- only caches node_modules
- uses packageName@packageVersion/path/in/package as cache key
- also caches file system handles during module graph calculation
- both caches together add up to a significant speedup